### PR TITLE
Added simple Kubernetes YAML

### DIFF
--- a/kubernetes/dmm-frontend.yaml
+++ b/kubernetes/dmm-frontend.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
         - name: dmm-frontend
-          image: bodom0015/dmm
+          image: moleculemaker/dmm-frontend
           ports:
             - containerPort: 80
           imagePullPolicy: Always


### PR DESCRIPTION
## Problem
We need a short-term approach for running the Docker image in Kubernetes for production

## Approach
* Added a simple YAML recipe for DMM: `kubernetes/dmm-frontend.yaml`

I skipped the Docker Compose part, but can add those too if developers would find it helpful :+1:
Helm chart would be nice, but this should be the bare minimum we would need to run in production

For local testing in Docker for Mac/Windows, you can enable Kubernetes in preferences:
<img width="1276" alt="Screen Shot 2023-03-03 at 6 47 45 PM" src="https://user-images.githubusercontent.com/1413653/222862923-11a35779-a185-4e23-9898-c71f1ed1e66c.png">

## How to Test
Prerequisites: 
* use #24 to build and push the Docker image (you may need to edit `image` in this YAML, if necessary)
* local k8s cluster running - you can use Docker for Mac/Windows, kind, minikube, etc
* Deploy local ingress controller in your cluster:
```bash
helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
helm repo update
helm upgrade --install -n kube-system nginx ingress-nginx/ingress-nginx --set controller.hostPort.enabled=true
```

Steps:
1. Checkout and run this branch locally
2. Create a namespace for `mmli`: `kubectl create ns mmli`
3. Use the YAML files to deploy DMM into Kubernetes in the `mmli` namespace: `kubectl apply -f kubernetes/ -n mmli`
4. Wait for the pod to start up successfully: `kubectl get pods -n mmli -w`
5. Navigate to `dmm.localhost` in your browser to access the dmm frontend

Cleanup:
You can shutdown/delete the DMM using the same YAML files: `kubectl delete -f kubernetes/ -n mmli`