### PR TITLE
pointed Matomo tracking at NCSA cluster and updated siteId

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -67,8 +67,8 @@ function initializeAppFactory(): () => Observable<null> {
     HttpClientModule,
     AppRoutingModule,
     NgxMatomoTrackerModule.forRoot({
-      siteId: 1,
-      trackerUrl: 'https://moleculemaker.matomo.cloud/'
+      siteId: 2,
+      trackerUrl: 'https://matomo.mmli1.ncsa.illinois.edu/'
     }),
     DragDropModule,
     OverlayModule


### PR DESCRIPTION
Previously, the Matomo configuration used Matomo's cloud-based service. This PR revises the configuration to use the Matomo instance Sara installed on our cluster.

Detailed tracking hasn't yet been implemented in the application, but here's a screenshot from Matomo showing that a visit from my local dev environment has been captured:

![image](https://user-images.githubusercontent.com/5361697/228015122-341ca745-2898-414f-bb43-44b5623c982f.png)
