### PR TITLE
fix: speed up arm64 Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use official node image as the base image
 # Node 14 is the most recent version compatible with Angular 12
-FROM node:16 as build
+FROM --platform=$BUILDPLATFORM node:16 as build
 
 # Set the working directory
 WORKDIR /usr/local/app


### PR DESCRIPTION
## Problem
`arm64` variant of frontend images builds very slowly

This will mainly affect developers with newer Macbook machines that use the newer M1 or M2 processors, which use the `arm64` chipset

## Approach
@robkooper recommended adding `--platform=$BUILDPLATFORM`

This should allow you to pull the image native to the host that you're using to build the image, which should speed up the build

## How to Test
Wait for the Checks tab to succeed here, then check the timing

To emulate building on `arm64`:
```
$ docker buildx build --platform=linux/arm64 . --no-cache
```

